### PR TITLE
feat: add tags support to AccountsPerspective filter and transformer

### DIFF
--- a/src/Database/Filters/AccountsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/AccountsPerspectiveQueryFilter.php
@@ -12,12 +12,32 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
 {
+    /**
+     * Filter by tags
+     *
+     * @param  $values
+     * @return Builder
+     */
+    public function tags($values)
+    {
+        $tags = explode(',', $values);
+
+        $search = '';
+
+        for($i = 0; $i < count($tags); $i++) {
+            $search .= "'" . trim($tags[$i]) . "',";
+        }
+
+        $search = substr($search, 0, -1);
+
+        return $this->builder->whereRaw('tags @> ARRAY[' . $search . ']');
+    }
 
     /**
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');

--- a/src/Database/Models/AccountsPerspective.php
+++ b/src/Database/Models/AccountsPerspective.php
@@ -50,6 +50,7 @@ use NextDeveloper\Commons\Database\Traits\HasObject;
  * @property string $disabling_reason
  * @property boolean $is_suspended
  * @property string $suspension_reason
+ * @property array $tags
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property \Carbon\Carbon $deleted_at
@@ -100,6 +101,7 @@ class AccountsPerspective extends Model
             'disabling_reason',
             'is_suspended',
             'suspension_reason',
+            'tags',
     ];
 
     /**
@@ -151,6 +153,7 @@ class AccountsPerspective extends Model
     'disabling_reason' => 'string',
     'is_suspended' => 'boolean',
     'suspension_reason' => 'string',
+    'tags' => \NextDeveloper\Commons\Database\Casts\TextArray::class,
     'created_at' => 'datetime',
     'updated_at' => 'datetime',
     'deleted_at' => 'datetime',

--- a/src/Database/Models/Campaigns.php
+++ b/src/Database/Models/Campaigns.php
@@ -171,6 +171,11 @@ class Campaigns extends Model
         return $this->belongsTo(\NextDeveloper\Flow\Database\Models\Stages::class);
     }
     
+    public function messages() : \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(\NextDeveloper\Communication\Database\Models\Messages::class);
+    }
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Http/Requests/AccountsPerspective/AccountsPerspectiveCreateRequest.php
+++ b/src/Http/Requests/AccountsPerspective/AccountsPerspectiveCreateRequest.php
@@ -41,6 +41,7 @@ class AccountsPerspectiveCreateRequest extends AbstractFormRequest
         'disabling_reason' => 'nullable|string',
         'is_suspended' => 'nullable|boolean',
         'suspension_reason' => 'nullable|string',
+        'tags' => 'nullable',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE

--- a/src/Http/Requests/AccountsPerspective/AccountsPerspectiveUpdateRequest.php
+++ b/src/Http/Requests/AccountsPerspective/AccountsPerspectiveUpdateRequest.php
@@ -41,6 +41,7 @@ class AccountsPerspectiveUpdateRequest extends AbstractFormRequest
         'disabling_reason' => 'nullable|string',
         'is_suspended' => 'nullable|boolean',
         'suspension_reason' => 'nullable|string',
+        'tags' => 'nullable',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE

--- a/src/Http/Transformers/AbstractTransformers/AbstractAccountsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAccountsPerspectiveTransformer.php
@@ -94,6 +94,7 @@ class AbstractAccountsPerspectiveTransformer extends AbstractTransformer
             'disabling_reason'  =>  $model->disabling_reason,
             'is_suspended'  =>  $model->is_suspended,
             'suspension_reason'  =>  $model->suspension_reason,
+            'tags'  =>  $model->tags,
             'created_at'  =>  $model->created_at,
             'updated_at'  =>  $model->updated_at,
             'deleted_at'  =>  $model->deleted_at,


### PR DESCRIPTION
## Summary
- crm_accounts_perspective now has a `tags` column; wire up the query filter, transformer, model casts, and create/update request validation to match the existing pattern used by IAM's AccountsPerspective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)